### PR TITLE
Allow 24h clock for defaultHour option

### DIFF
--- a/src/django_flatpickr/schemas.py
+++ b/src/django_flatpickr/schemas.py
@@ -33,7 +33,7 @@ class FlatpickrOptions(BaseModel, extra=Extra.allow):
     clickOpens: Optional[bool]
     dateFormat: Optional[str]
     defaultDate: Optional[str]
-    defaultHour: Optional[int] = Field(ge=1, le=12)
+    defaultHour: Optional[int] = Field(ge=0, le=23)
     defaultMinute: Optional[int] = Field(ge=0, le=59)
     disable: Optional[List[str]]
     disableMobile: Optional[bool]


### PR DESCRIPTION
Hey!

Flatpickr can handle 24 hour clocks so it would be great if we could allow this for the `defaultHour` config.