### PR TITLE
Fix DomNodeInserted Deprecation

### DIFF
--- a/src/django_flatpickr/static/django_flatpickr/js/django-flatpickr.js
+++ b/src/django_flatpickr/static/django_flatpickr/js/django-flatpickr.js
@@ -50,13 +50,18 @@
     throw err;
   }
 
-  document.addEventListener('DOMContentLoaded', function (event) {
-    findAndProcessFlatpickrInputs(document);
-    document.addEventListener('DOMNodeInserted', function (event) {
-      setTimeout(() => {
-        if (event.target.querySelectorAll) findAndProcessFlatpickrInputs(event.target);
+  const observer = new MutationObserver((records, _observer) => {
+    records.forEach(record => {
+      record.addedNodes.forEach(node => {
+        if (node.nodeType === Node.ELEMENT_NODE) findAndProcessFlatpickrInputs(node)
       });
     });
+  });
+
+  observer.observe(document.body, {childList: true})
+
+  document.addEventListener('DOMContentLoaded', function (event) {
+    findAndProcessFlatpickrInputs(document.body);
   });
 
   /**

--- a/src/django_flatpickr/static/django_flatpickr/js/django-flatpickr.js
+++ b/src/django_flatpickr/static/django_flatpickr/js/django-flatpickr.js
@@ -53,7 +53,7 @@
   const observer = new MutationObserver((records, _observer) => {
     records.forEach(record => {
       record.addedNodes.forEach(node => {
-        if (node.nodeType === Node.ELEMENT_NODE) findAndProcessFlatpickrInputs(node)
+        if (node.querySelectorAll) findAndProcessFlatpickrInputs(node);
       });
     });
   });


### PR DESCRIPTION
# Fix DomNodeInserted Deprecation

## Purpose
The MutationEvent API has been deprecated (#21)  and some browsers already dropped support completely [MDN](https://developer.mozilla.org/en-US/docs/Web/API/MutationEvent). This causes a warning in the developer console and prevents flatpickrs which are inserted through e.g. a modal (#16 ) from being initialized. 

## Approach
Removed the DOMNodeInserted event listener and replaced it with a MutationObserver

#### Issues solved in this PR
- #21
- #16

#### What has Changed
- django-flatpickr.js